### PR TITLE
⚡️ $USDC Zap

### DIFF
--- a/deployments/BaseGoerli.json
+++ b/deployments/BaseGoerli.json
@@ -4,8 +4,8 @@
         "TrustedMulticallForwarder": "0xB49d495c5aFC5e5CE113c1dCb016771925034707"
     },
     "Andromeda": {
-        "Engine": "0x8738276bcA829e89a840FF1bb7f75D630B74dFAC",
-        "TrustedMulticallForwarder": "0xBaA24D0839B9Bb2240CA8AABa7576664f1340bcA"
+        "Engine": "0xDD13e7e5C7bc8ca2b2d5fF9C2C37700E292C11D2",
+        "TrustedMulticallForwarder": "0x5A46492912EA26C48991e9FD74f67e840dDe2f02"
     },
     "Kwenta": {
         "Engine": "0x0b5456EB6eE169C533a931aD2a420237ADf3Da49",

--- a/deployments/BaseGoerli.json
+++ b/deployments/BaseGoerli.json
@@ -4,8 +4,8 @@
         "TrustedMulticallForwarder": "0xB49d495c5aFC5e5CE113c1dCb016771925034707"
     },
     "Andromeda": {
-        "Engine": "0xDD13e7e5C7bc8ca2b2d5fF9C2C37700E292C11D2",
-        "TrustedMulticallForwarder": "0x5A46492912EA26C48991e9FD74f67e840dDe2f02"
+        "Engine": "0xDE61E43fbe7919040b19afeEfEb01BFE25b87b6d",
+        "TrustedMulticallForwarder": "0x78016932540193e2E80683B8F9Be222729eF08D4"
     },
     "Kwenta": {
         "Engine": "0x0b5456EB6eE169C533a931aD2a420237ADf3Da49",

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -27,7 +27,8 @@ contract Setup is Script {
         address perpsMarketProxy,
         address spotMarketProxy,
         address sUSDProxy,
-        address oracle
+        address oracle,
+        address usdc
     )
         public
         returns (
@@ -42,7 +43,8 @@ contract Setup is Script {
             _spotMarketProxy: spotMarketProxy,
             _sUSDProxy: sUSDProxy,
             _oracle: oracle,
-            _trustedForwarder: address(trustedForwarderContract)
+            _trustedForwarder: address(trustedForwarderContract),
+            _usdc: usdc
         });
     }
 }
@@ -59,7 +61,8 @@ contract DeployBase_Synthetix is Setup, BaseParameters {
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         vm.stopBroadcast();
@@ -78,7 +81,8 @@ contract DeployBaseGoerli_Synthetix is Setup, BaseGoerliParameters {
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         vm.stopBroadcast();
@@ -100,7 +104,8 @@ contract DeployBaseGoerli_KwentaFork is
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         vm.stopBroadcast();
@@ -119,7 +124,8 @@ contract DeployBaseGoerli_Andromeda is Setup, BaseGoerliParameters {
             perpsMarketProxy: PERPS_MARKET_PROXY_ANDROMEDA,
             spotMarketProxy: SPOT_MARKET_PROXY_ANDROMEDA,
             sUSDProxy: USD_PROXY_ANDROMEDA,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         vm.stopBroadcast();
@@ -138,7 +144,8 @@ contract DeployOptimism_Synthetix is Setup, OptimismParameters {
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         vm.stopBroadcast();
@@ -157,7 +164,8 @@ contract DeployOptimismGoerli_Synthetix is Setup, OptimismGoerliParameters {
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         vm.stopBroadcast();

--- a/script/utils/parameters/BaseGoerliKwentaForkParameters.sol
+++ b/script/utils/parameters/BaseGoerliKwentaForkParameters.sol
@@ -12,4 +12,6 @@ contract BaseGoerliKwentaForkParameters {
         0xD3bcDae94B0c2EF16d1c43d29c23b1735d864fC6;
 
     address public constant PYTH = 0x5955C1478F0dAD753C7E2B4dD1b4bC530C64749f;
+
+    address public constant USDC = 0x2e9F75DF8839ff192Da27e977CD154FD1EAE03cf;
 }

--- a/script/utils/parameters/BaseGoerliParameters.sol
+++ b/script/utils/parameters/BaseGoerliParameters.sol
@@ -13,7 +13,7 @@ contract BaseGoerliParameters {
 
     address public constant PYTH = 0x5955C1478F0dAD753C7E2B4dD1b4bC530C64749f;
 
-    address public constant USDC = 0x2e9F75DF8839ff192Da27e977CD154FD1EAE03cf;
+    address public constant USDC = 0x7056F16f58638253B8A1E5023d67a8CF98000681;
 
     address public constant PERPS_MARKET_PROXY_ANDROMEDA =
         0xEED61f0CB02f3B38923b1b6EAa939D5f04f431b6;

--- a/script/utils/parameters/BaseGoerliParameters.sol
+++ b/script/utils/parameters/BaseGoerliParameters.sol
@@ -13,6 +13,8 @@ contract BaseGoerliParameters {
 
     address public constant PYTH = 0x5955C1478F0dAD753C7E2B4dD1b4bC530C64749f;
 
+    address public constant USDC = 0x2e9F75DF8839ff192Da27e977CD154FD1EAE03cf;
+
     address public constant PERPS_MARKET_PROXY_ANDROMEDA =
         0xEED61f0CB02f3B38923b1b6EAa939D5f04f431b6;
 

--- a/script/utils/parameters/BaseParameters.sol
+++ b/script/utils/parameters/BaseParameters.sol
@@ -9,4 +9,6 @@ contract BaseParameters {
     address public constant USD_PROXY = address(0);
 
     address public constant PYTH = 0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a;
+
+    address public constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
 }

--- a/script/utils/parameters/OptimismGoerliParameters.sol
+++ b/script/utils/parameters/OptimismGoerliParameters.sol
@@ -12,4 +12,6 @@ contract OptimismGoerliParameters {
         0xe487Ad4291019b33e2230F8E2FB1fb6490325260;
 
     address public constant PYTH = 0xff1a0f4744e8582DF1aE09D5611b887B6a12925C;
+
+    address public constant USDC = address(0xDEAD);
 }

--- a/script/utils/parameters/OptimismParameters.sol
+++ b/script/utils/parameters/OptimismParameters.sol
@@ -11,4 +11,6 @@ contract OptimismParameters {
         0xb2F30A7C980f052f02563fb518dcc39e6bf38175;
 
     address public constant PYTH = 0xff1a0f4744e8582DF1aE09D5611b887B6a12925C;
+
+    address public constant USDC = 0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85;
 }

--- a/src/Engine.sol
+++ b/src/Engine.sol
@@ -79,6 +79,9 @@ contract Engine is IEngine, EIP712, EIP7412, ERC2771Context {
     /// @notice Synthetix v3 $sUSD contract
     IERC20 internal immutable SUSD;
 
+    /// @notice $USDC contract
+    IERC20 internal immutable USDC;
+
     /*//////////////////////////////////////////////////////////////
                                  STATE
     //////////////////////////////////////////////////////////////*/
@@ -103,23 +106,27 @@ contract Engine is IEngine, EIP712, EIP7412, ERC2771Context {
     /// @param _sUSDProxy Synthetix v3 $sUSD contract
     /// @param _oracle pyth oracle contract used to get asset prices
     /// @param _trustedForwarder trusted forwarder contract used for meta transactions
+    /// @param _usdc $USDC contract address
     constructor(
         address _perpsMarketProxy,
         address _spotMarketProxy,
         address _sUSDProxy,
         address _oracle,
-        address _trustedForwarder
+        address _trustedForwarder,
+        address _usdc
     ) ERC2771Context(_trustedForwarder) {
         if (_perpsMarketProxy == address(0)) revert ZeroAddress();
         if (_spotMarketProxy == address(0)) revert ZeroAddress();
         if (_sUSDProxy == address(0)) revert ZeroAddress();
         if (_oracle == address(0)) revert ZeroAddress();
         if (_trustedForwarder == address(0)) revert ZeroAddress();
+        if (_usdc == address(0)) revert ZeroAddress();
 
         PERPS_MARKET_PROXY = IPerpsMarketProxy(_perpsMarketProxy);
         SPOT_MARKET_PROXY = ISpotMarketProxy(_spotMarketProxy);
         SUSD = IERC20(_sUSDProxy);
         ORACLE = IPyth(_oracle);
+        USDC = IERC20(_usdc);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -320,7 +327,6 @@ contract Engine is IEngine, EIP712, EIP7412, ERC2771Context {
     /// @inheritdoc IEngine
     function zap(
         uint128 _accountId,
-        address _usdc,
         uint128 _synthMarketId,
         int256 _amount,
         address _referrer
@@ -334,9 +340,6 @@ contract Engine is IEngine, EIP712, EIP7412, ERC2771Context {
         ) {
             revert ZapFailed();
         }
-
-        // define $USDC contract
-        IERC20 USDC = IERC20(_usdc);
 
         // define $sUSDC synth contract
         IERC20 sUSDC = IERC20(_getSynthAddress(_synthMarketId));

--- a/src/interfaces/IEngine.sol
+++ b/src/interfaces/IEngine.sol
@@ -180,11 +180,13 @@ interface IEngine {
     /// @notice "zap" $USDC for $sUSD and deposit the $sUSD into the perps market proxy
     /// or withdraw the $sUSD from the perps market proxy and "zap" $sUSD for $USDC
     /// @param _accountId the account id to modify collateral for
+    /// @param _usdc the address of the $USDC contract
     /// @param _synthMarketId the id of the synth market (i.e. $sUSDC)
     /// @param _amount the amount of $USDC to deposit/withdraw
     /// @param _referrer the address of the referrer
     function zap(
         uint128 _accountId,
+        address _usdc,
         uint128 _synthMarketId,
         int256 _amount,
         address _referrer

--- a/src/interfaces/IEngine.sol
+++ b/src/interfaces/IEngine.sol
@@ -77,6 +77,9 @@ interface IEngine {
     /// @notice thrown when attempting to transfer eth fails
     error EthTransferFailed();
 
+    /// @notice thrown when zap fails
+    error ZapFailed();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -173,6 +176,19 @@ interface IEngine {
     /*//////////////////////////////////////////////////////////////
                          COLLATERAL MANAGEMENT
     //////////////////////////////////////////////////////////////*/
+
+    /// @notice "zap" $USDC for $sUSD and deposit the $sUSD into the perps market proxy
+    /// or withdraw the $sUSD from the perps market proxy and "zap" $sUSD for $USDC
+    /// @param _accountId the account id to modify collateral for
+    /// @param _synthMarketId the id of the synth market (i.e. $sUSDC)
+    /// @param _amount the amount of $USDC to deposit/withdraw
+    /// @param _referrer the address of the referrer
+    function zap(
+        uint128 _accountId,
+        uint128 _synthMarketId,
+        int256 _amount,
+        address _referrer
+    ) external;
 
     /// @notice modify the collateral of an account identified by the accountId
     /// @param _accountId the account to modify

--- a/src/interfaces/IEngine.sol
+++ b/src/interfaces/IEngine.sol
@@ -180,13 +180,11 @@ interface IEngine {
     /// @notice "zap" $USDC for $sUSD and deposit the $sUSD into the perps market proxy
     /// or withdraw the $sUSD from the perps market proxy and "zap" $sUSD for $USDC
     /// @param _accountId the account id to modify collateral for
-    /// @param _usdc the address of the $USDC contract
     /// @param _synthMarketId the id of the synth market (i.e. $sUSDC)
     /// @param _amount the amount of $USDC to deposit/withdraw
     /// @param _referrer the address of the referrer
     function zap(
         uint128 _accountId,
-        address _usdc,
         uint128 _synthMarketId,
         int256 _amount,
         address _referrer

--- a/src/interfaces/synthetix/ISpotMarketProxy.sol
+++ b/src/interfaces/synthetix/ISpotMarketProxy.sol
@@ -6,6 +6,13 @@ pragma solidity 0.8.20;
 /// @author Synthetix
 interface ISpotMarketProxy {
     /*//////////////////////////////////////////////////////////////
+                            MARKET INTERFACE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice returns a human-readable name for a given market
+    function name(uint128 marketId) external view returns (string memory);
+
+    /*//////////////////////////////////////////////////////////////
                        SPOT MARKET FACTORY MODULE
     //////////////////////////////////////////////////////////////*/
 
@@ -17,4 +24,73 @@ interface ISpotMarketProxy {
         external
         view
         returns (address synthAddress);
+
+    /*//////////////////////////////////////////////////////////////
+                             WRAPPER MODULE
+    //////////////////////////////////////////////////////////////*/
+
+    struct Data {
+        uint256 fixedFees;
+        uint256 utilizationFees;
+        int256 skewFees;
+        int256 wrapperFees;
+    }
+
+    /// @notice Wraps the specified amount and returns similar value of synth minus the fees.
+    /// @dev Fees are collected from the user by way of the contract returning less synth than specified amount of collateral.
+    /// @param marketId Id of the market used for the trade.
+    /// @param wrapAmount Amount of collateral to wrap.  This amount gets deposited into the market collateral manager.
+    /// @param minAmountReceived The minimum amount of synths the trader is expected to receive, otherwise the transaction will revert.
+    /// @return amountToMint Amount of synth returned to user.
+    /// @return fees breakdown of all fees. in this case, only wrapper fees are returned.
+    function wrap(
+        uint128 marketId,
+        uint256 wrapAmount,
+        uint256 minAmountReceived
+    ) external returns (uint256 amountToMint, Data memory fees);
+
+    /// @notice Unwraps the synth and returns similar value of collateral minus the fees.
+    /// @dev Transfers the specified synth, collects fees through configured fee collector, returns collateral minus fees to trader.
+    /// @param marketId Id of the market used for the trade.
+    /// @param unwrapAmount Amount of synth trader is unwrapping.
+    /// @param minAmountReceived The minimum amount of collateral the trader is expected to receive, otherwise the transaction will revert.
+    /// @return returnCollateralAmount Amount of collateral returned.
+    /// @return fees breakdown of all fees. in this case, only wrapper fees are returned.
+    function unwrap(
+        uint128 marketId,
+        uint256 unwrapAmount,
+        uint256 minAmountReceived
+    ) external returns (uint256 returnCollateralAmount, Data memory fees);
+
+    /*//////////////////////////////////////////////////////////////
+                          ATOMIC ORDER MODULE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice alias for buyExactIn
+    /// @param marketId (see buyExactIn)
+    /// @param usdAmount (see buyExactIn)
+    /// @param minAmountReceived (see buyExactIn)
+    /// @param referrer (see buyExactIn)
+    /// @return synthAmount (see buyExactIn)
+    /// @return fees (see buyExactIn)
+    function buy(
+        uint128 marketId,
+        uint256 usdAmount,
+        uint256 minAmountReceived,
+        address referrer
+    ) external returns (uint256 synthAmount, Data memory fees);
+
+    /// @notice alias for sellExactIn
+    /// @param marketId (see sellExactIn)
+    /// @param synthAmount (see sellExactIn)
+    /// @param minUsdAmount (see sellExactIn)
+    /// @param referrer (see sellExactIn)
+    /// @return usdAmountReceived (see sellExactIn)
+    /// @return fees (see sellExactIn)
+    function sell(
+        uint128 marketId,
+        uint256 synthAmount,
+        uint256 minUsdAmount,
+        address referrer
+    ) external returns (uint256 usdAmountReceived, Data memory fees);
 }

--- a/test/AsyncOrder.t.sol
+++ b/test/AsyncOrder.t.sol
@@ -29,7 +29,7 @@ contract CommitOrder is AsyncOrderTest {
 
         (IPerpsMarketProxy.Data memory retOrder, uint256 fees) = engine
             .commitOrder({
-            _perpsMarketId: SETH_PERPS_MARKET_ID,
+            _perpsMarketId: sETHPerpsMarketId,
             _accountId: accountId,
             _sizeDelta: 1 ether,
             _settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -40,7 +40,7 @@ contract CommitOrder is AsyncOrderTest {
 
         // retOrder
         assertTrue(retOrder.settlementTime != 0);
-        assertTrue(retOrder.request.marketId == SETH_PERPS_MARKET_ID);
+        assertTrue(retOrder.request.marketId == sETHPerpsMarketId);
         assertTrue(retOrder.request.accountId == accountId);
         assertTrue(retOrder.request.sizeDelta == 1 ether);
         assertTrue(retOrder.request.settlementStrategyId == 0);
@@ -76,7 +76,7 @@ contract CommitOrder is AsyncOrderTest {
         int128 sizeDelta = 1000 ether;
 
         uint256 requiredMargin = perpsMarketProxy.requiredMarginForOrder(
-            accountId, SETH_PERPS_MARKET_ID, sizeDelta
+            accountId, sETHPerpsMarketId, sizeDelta
         );
 
         int256 availableMargin = perpsMarketProxy.getAvailableMargin(accountId);
@@ -92,7 +92,7 @@ contract CommitOrder is AsyncOrderTest {
         );
 
         engine.commitOrder({
-            _perpsMarketId: SETH_PERPS_MARKET_ID,
+            _perpsMarketId: sETHPerpsMarketId,
             _accountId: accountId,
             _sizeDelta: sizeDelta,
             _settlementStrategyId: SETTLEMENT_STRATEGY_ID,

--- a/test/ConditionalOrder.t.sol
+++ b/test/ConditionalOrder.t.sol
@@ -60,7 +60,7 @@ contract CanExecute is ConditionalOrderTest {
 
     function _defineConditionalOrder() internal {
         orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -337,7 +337,7 @@ contract VerifyConditions is ConditionalOrderTest {
         mock_getOpenPosition({
             perpsMarketProxy: address(perpsMarketProxy),
             accountId: accountId,
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             positionSize: 1 ether
         });
 
@@ -348,13 +348,11 @@ contract VerifyConditions is ConditionalOrderTest {
         conditions[3] = isPriceBelow(
             PYTH_ETH_USD_ASSET_ID, type(int64).max, type(uint64).max
         );
-        conditions[4] = isMarketOpen(SETH_PERPS_MARKET_ID);
-        conditions[5] = isPositionSizeAbove(accountId, SETH_PERPS_MARKET_ID, 0);
-        conditions[6] = isPositionSizeBelow(
-            accountId, SETH_PERPS_MARKET_ID, type(int64).max
-        );
-        conditions[7] =
-            isOrderFeeBelow(SETH_PERPS_MARKET_ID, 1, type(uint256).max);
+        conditions[4] = isMarketOpen(sETHPerpsMarketId);
+        conditions[5] = isPositionSizeAbove(accountId, sETHPerpsMarketId, 0);
+        conditions[6] =
+            isPositionSizeBelow(accountId, sETHPerpsMarketId, type(int64).max);
+        conditions[7] = isOrderFeeBelow(sETHPerpsMarketId, 1, type(uint256).max);
 
         IEngine.OrderDetails memory orderDetails;
 
@@ -389,7 +387,7 @@ contract VerifyConditions is ConditionalOrderTest {
         conditions[1] = isTimestampBefore(type(uint256).max);
         conditions[2] = isPriceAbove(PYTH_ETH_USD_ASSET_ID, 0, type(uint64).max);
         conditions[3] = isPriceBelow(PYTH_ETH_USD_ASSET_ID, 0, type(uint64).max); // false
-        conditions[4] = isMarketOpen(SETH_PERPS_MARKET_ID);
+        conditions[4] = isMarketOpen(sETHPerpsMarketId);
 
         IEngine.OrderDetails memory orderDetails;
 
@@ -411,7 +409,7 @@ contract VerifyConditions is ConditionalOrderTest {
     function test_verifyConditions_InvalidConditionSelector() public {
         bytes[] memory conditions = new bytes[](1);
         conditions[0] = abi.encodeWithSignature(
-            "_getSynthAddress(uint128 _synthMarketId)", SETH_SPOT_MARKET_ID
+            "_getSynthAddress(uint128 _synthMarketId)", sETHSpotMarketId
         );
 
         IEngine.OrderDetails memory orderDetails;
@@ -443,7 +441,7 @@ contract Execute is ConditionalOrderTest {
 
     function test_execute_order_committed() public {
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -474,7 +472,7 @@ contract Execute is ConditionalOrderTest {
 
         // retOrder
         assertTrue(retOrder.settlementTime != 0);
-        assertTrue(retOrder.request.marketId == SETH_PERPS_MARKET_ID);
+        assertTrue(retOrder.request.marketId == sETHPerpsMarketId);
         assertTrue(retOrder.request.accountId == accountId);
         assertTrue(retOrder.request.sizeDelta == 1 ether);
         assertTrue(retOrder.request.settlementStrategyId == 0);
@@ -488,7 +486,7 @@ contract Execute is ConditionalOrderTest {
 
     function test_execute_event() public {
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -525,7 +523,7 @@ contract Execute is ConditionalOrderTest {
 
     function test_execute_CannotExecuteOrder_too_leveraged() public {
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: INVALID_SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -559,7 +557,7 @@ contract Execute is ConditionalOrderTest {
 
     function test_execute_CannotExecuteOrder_invalid_acceptablePrice() public {
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -595,7 +593,7 @@ contract Execute is ConditionalOrderTest {
         public
     {
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: INVALID_SETTLEMENT_STRATEGY_ID,
@@ -637,7 +635,7 @@ contract Fee is ConditionalOrderTest {
         engine.depositEth{value: 1 ether}(accountId);
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -676,7 +674,7 @@ contract Fee is ConditionalOrderTest {
         engine.depositEth{value: CO_FEE - 1}(accountId);
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -711,7 +709,7 @@ contract Fee is ConditionalOrderTest {
         engine.depositEth{value: 1 ether}(accountId);
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -746,11 +744,11 @@ contract Fee is ConditionalOrderTest {
 contract ReduceOnly is ConditionalOrderTest {
     function test_reduce_only() public {
         mock_getOpenPosition(
-            address(perpsMarketProxy), accountId, SETH_PERPS_MARKET_ID, -1 ether
+            address(perpsMarketProxy), accountId, sETHPerpsMarketId, -1 ether
         );
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -784,7 +782,7 @@ contract ReduceOnly is ConditionalOrderTest {
 
     function test_reduce_only_zero_size() public {
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -817,11 +815,11 @@ contract ReduceOnly is ConditionalOrderTest {
 
     function test_reduce_only_same_sign() public {
         mock_getOpenPosition(
-            address(perpsMarketProxy), accountId, SETH_PERPS_MARKET_ID, 1 ether
+            address(perpsMarketProxy), accountId, sETHPerpsMarketId, 1 ether
         );
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -854,11 +852,11 @@ contract ReduceOnly is ConditionalOrderTest {
 
     function test_reduce_only_truncate_size_down() public {
         mock_getOpenPosition(
-            address(perpsMarketProxy), accountId, SETH_PERPS_MARKET_ID, -1 ether
+            address(perpsMarketProxy), accountId, sETHPerpsMarketId, -1 ether
         );
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: type(int128).max,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -893,11 +891,11 @@ contract ReduceOnly is ConditionalOrderTest {
 
     function test_reduce_only_truncate_size_up() public {
         mock_getOpenPosition(
-            address(perpsMarketProxy), accountId, SETH_PERPS_MARKET_ID, 1 ether
+            address(perpsMarketProxy), accountId, sETHPerpsMarketId, 1 ether
         );
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: -type(int128).max,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,
@@ -1021,14 +1019,12 @@ contract Conditions is ConditionalOrderTest {
     }
 
     function test_isMarketOpen() public {
-        bool isOpen = engine.isMarketOpen(SETH_PERPS_MARKET_ID);
+        bool isOpen = engine.isMarketOpen(sETHPerpsMarketId);
         assertTrue(isOpen);
 
-        mock_getMaxMarketSize(
-            MARKET_CONFIGURATION_MODULE, SETH_PERPS_MARKET_ID, 0
-        );
+        mock_getMaxMarketSize(MARKET_CONFIGURATION_MODULE, sETHPerpsMarketId, 0);
 
-        isOpen = engine.isMarketOpen(SETH_PERPS_MARKET_ID);
+        isOpen = engine.isMarketOpen(sETHPerpsMarketId);
         assertFalse(isOpen);
     }
 
@@ -1037,22 +1033,22 @@ contract Conditions is ConditionalOrderTest {
         mock_getOpenPosition({
             perpsMarketProxy: address(perpsMarketProxy),
             accountId: accountId,
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             positionSize: mock_positionSize
         });
 
         bool isAbove = engine.isPositionSizeAbove(
-            accountId, SETH_PERPS_MARKET_ID, mock_positionSize - 1
+            accountId, sETHPerpsMarketId, mock_positionSize - 1
         );
         assertTrue(isAbove);
 
         isAbove = engine.isPositionSizeAbove(
-            accountId, SETH_PERPS_MARKET_ID, mock_positionSize
+            accountId, sETHPerpsMarketId, mock_positionSize
         );
         assertFalse(isAbove);
 
         isAbove = engine.isPositionSizeAbove(
-            accountId, SETH_PERPS_MARKET_ID, mock_positionSize + 1
+            accountId, sETHPerpsMarketId, mock_positionSize + 1
         );
         assertFalse(isAbove);
     }
@@ -1062,22 +1058,22 @@ contract Conditions is ConditionalOrderTest {
         mock_getOpenPosition({
             perpsMarketProxy: address(perpsMarketProxy),
             accountId: accountId,
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             positionSize: mock_positionSize
         });
 
         bool isBelow = engine.isPositionSizeBelow(
-            accountId, SETH_PERPS_MARKET_ID, mock_positionSize - 1
+            accountId, sETHPerpsMarketId, mock_positionSize - 1
         );
         assertFalse(isBelow);
 
         isBelow = engine.isPositionSizeBelow(
-            accountId, SETH_PERPS_MARKET_ID, mock_positionSize
+            accountId, sETHPerpsMarketId, mock_positionSize
         );
         assertFalse(isBelow);
 
         isBelow = engine.isPositionSizeBelow(
-            accountId, SETH_PERPS_MARKET_ID, mock_positionSize + 1
+            accountId, sETHPerpsMarketId, mock_positionSize + 1
         );
         assertTrue(isBelow);
     }
@@ -1085,22 +1081,20 @@ contract Conditions is ConditionalOrderTest {
     function test_isOrderFeeBelow() public {
         int128 sizeDelta = 1 ether;
         (uint256 orderFees,) = perpsMarketProxy.computeOrderFees({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             sizeDelta: sizeDelta
         });
 
-        bool isBelow = engine.isOrderFeeBelow(
-            SETH_PERPS_MARKET_ID, sizeDelta, orderFees - 1
-        );
+        bool isBelow =
+            engine.isOrderFeeBelow(sETHPerpsMarketId, sizeDelta, orderFees - 1);
         assertFalse(isBelow);
 
         isBelow =
-            engine.isOrderFeeBelow(SETH_PERPS_MARKET_ID, sizeDelta, orderFees);
+            engine.isOrderFeeBelow(sETHPerpsMarketId, sizeDelta, orderFees);
         assertFalse(isBelow);
 
-        isBelow = engine.isOrderFeeBelow(
-            SETH_PERPS_MARKET_ID, sizeDelta, orderFees + 1
-        );
+        isBelow =
+            engine.isOrderFeeBelow(sETHPerpsMarketId, sizeDelta, orderFees + 1);
         assertTrue(isBelow);
     }
 }

--- a/test/Deployment.t.sol
+++ b/test/Deployment.t.sol
@@ -20,7 +20,8 @@ contract DeploymentTest is Test, Setup {
             perpsMarketProxy: address(0x1),
             spotMarketProxy: address(0x2),
             sUSDProxy: address(0x3),
-            oracle: address(0x4)
+            oracle: address(0x4),
+            usdc: address(0x5)
         });
 
         assertTrue(address(engine) != address(0x0));
@@ -32,7 +33,8 @@ contract DeploymentTest is Test, Setup {
             perpsMarketProxy: address(0),
             spotMarketProxy: address(0x2),
             sUSDProxy: address(0x3),
-            oracle: address(0x4)
+            oracle: address(0x4),
+            usdc: address(0x5)
         }) {} catch (bytes memory reason) {
             assertEq(bytes4(reason), IEngine.ZeroAddress.selector);
         }
@@ -43,7 +45,8 @@ contract DeploymentTest is Test, Setup {
             perpsMarketProxy: address(0x1),
             spotMarketProxy: address(0),
             sUSDProxy: address(0x3),
-            oracle: address(0x4)
+            oracle: address(0x4),
+            usdc: address(0x5)
         }) {} catch (bytes memory reason) {
             assertEq(bytes4(reason), IEngine.ZeroAddress.selector);
         }
@@ -54,7 +57,8 @@ contract DeploymentTest is Test, Setup {
             perpsMarketProxy: address(0x1),
             spotMarketProxy: address(0x2),
             sUSDProxy: address(0),
-            oracle: address(0x4)
+            oracle: address(0x4),
+            usdc: address(0x5)
         }) {} catch (bytes memory reason) {
             assertEq(bytes4(reason), IEngine.ZeroAddress.selector);
         }
@@ -65,7 +69,8 @@ contract DeploymentTest is Test, Setup {
             perpsMarketProxy: address(0x1),
             spotMarketProxy: address(0x2),
             sUSDProxy: address(0x3),
-            oracle: address(0)
+            oracle: address(0),
+            usdc: address(0x5)
         }) {} catch (bytes memory reason) {
             assertEq(bytes4(reason), IEngine.ZeroAddress.selector);
         }
@@ -79,7 +84,20 @@ contract DeploymentTest is Test, Setup {
             _spotMarketProxy: address(0x2),
             _sUSDProxy: address(0x3),
             _oracle: address(0x4),
-            _trustedForwarder: address(0)
+            _trustedForwarder: address(0),
+            _usdc: address(0x5)
+        }) {} catch (bytes memory reason) {
+            assertEq(bytes4(reason), IEngine.ZeroAddress.selector);
+        }
+    }
+
+    function test_deploy_usdc_zero_address() public {
+        try setup.deploySystem({
+            perpsMarketProxy: address(0x1),
+            spotMarketProxy: address(0x2),
+            sUSDProxy: address(0x3),
+            oracle: address(0x4),
+            usdc: address(0)
         }) {} catch (bytes memory reason) {
             assertEq(bytes4(reason), IEngine.ZeroAddress.selector);
         }

--- a/test/NonceBitmap.t.sol
+++ b/test/NonceBitmap.t.sol
@@ -49,7 +49,7 @@ contract NonceBitmapTest is Bootstrap, ConditionalOrderSignature {
         uint256 mask = type(uint256).max;
 
         IEngine.OrderDetails memory orderDetails = IEngine.OrderDetails({
-            marketId: SETH_PERPS_MARKET_ID,
+            marketId: sETHPerpsMarketId,
             accountId: accountId,
             sizeDelta: SIZE_DELTA,
             settlementStrategyId: SETTLEMENT_STRATEGY_ID,

--- a/test/utils/Bootstrap.sol
+++ b/test/utils/Bootstrap.sol
@@ -31,6 +31,7 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
     ISpotMarketProxy public spotMarketProxy;
     IERC20 public sUSD;
     IERC20 public sBTC;
+    IERC20 public USDC;
     IPyth public pyth;
 
     SynthMinter public synthMinter;
@@ -47,7 +48,8 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
             address _spotMarketProxyAddress,
             address _sUSDAddress,
             address _pythAddress,
-            address _trustedForwarderAddress
+            address _trustedForwarderAddress,
+            address _usdcAddress
         ) = bootstrap.init();
 
         engine = Engine(_engineAddress);
@@ -60,6 +62,7 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         pyth = IPyth(_pythAddress);
         synthMinter = new SynthMinter(_sUSDAddress, _spotMarketProxyAddress);
         sBTC = synthMinter.sBTC();
+        USDC = IERC20(_usdcAddress);
 
         vm.startPrank(ACTOR);
         accountId = perpsMarketProxy.createAccount();
@@ -71,6 +74,8 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         vm.stopPrank();
 
         synthMinter.mint_sUSD(ACTOR, AMOUNT);
+
+        /// @custom:todo mint USDC?
     }
 
     function initializeOptimism() public {
@@ -82,7 +87,8 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
             address _spotMarketProxyAddress,
             address _sUSDAddress,
             address _pythAddress,
-            address _trustedForwarderAddress
+            address _trustedForwarderAddress,
+            address _usdcAddress
         ) = bootstrap.init();
 
         engine = Engine(_engineAddress);
@@ -95,6 +101,7 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         pyth = IPyth(_pythAddress);
         synthMinter = new SynthMinter(_sUSDAddress, _spotMarketProxyAddress);
         sBTC = synthMinter.sBTC();
+        USDC = IERC20(_usdcAddress);
 
         vm.startPrank(ACTOR);
         accountId = perpsMarketProxy.createAccount();
@@ -106,20 +113,32 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         vm.stopPrank();
 
         synthMinter.mint_sUSD(ACTOR, AMOUNT);
+
+        /// @custom:todo mint USDC?
     }
 }
 
 contract BootstrapOptimism is Setup, OptimismParameters {
     function init()
         public
-        returns (address, address, address, address, address, address, address)
+        returns (
+            address,
+            address,
+            address,
+            address,
+            address,
+            address,
+            address,
+            address
+        )
     {
         (Engine engine, TrustedMulticallForwarder trustedForwarderContract) =
         Setup.deploySystem({
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         EngineExposed engineExposed = new EngineExposed({
@@ -127,7 +146,8 @@ contract BootstrapOptimism is Setup, OptimismParameters {
             _spotMarketProxy: SPOT_MARKET_PROXY,
             _sUSDProxy: USD_PROXY,
             _oracle: PYTH,
-            _trustedForwarder: address(0x1)
+            _trustedForwarder: address(0x1),
+            _usdc: USDC
         });
 
         return (
@@ -137,7 +157,8 @@ contract BootstrapOptimism is Setup, OptimismParameters {
             SPOT_MARKET_PROXY,
             USD_PROXY,
             PYTH,
-            address(trustedForwarderContract)
+            address(trustedForwarderContract),
+            USDC
         );
     }
 }
@@ -145,14 +166,24 @@ contract BootstrapOptimism is Setup, OptimismParameters {
 contract BootstrapOptimismGoerli is Setup, OptimismGoerliParameters {
     function init()
         public
-        returns (address, address, address, address, address, address, address)
+        returns (
+            address,
+            address,
+            address,
+            address,
+            address,
+            address,
+            address,
+            address
+        )
     {
         (Engine engine, TrustedMulticallForwarder trustedForwarderContract) =
         Setup.deploySystem({
             perpsMarketProxy: PERPS_MARKET_PROXY,
             spotMarketProxy: SPOT_MARKET_PROXY,
             sUSDProxy: USD_PROXY,
-            oracle: PYTH
+            oracle: PYTH,
+            usdc: USDC
         });
 
         EngineExposed engineExposed = new EngineExposed({
@@ -160,7 +191,8 @@ contract BootstrapOptimismGoerli is Setup, OptimismGoerliParameters {
             _spotMarketProxy: SPOT_MARKET_PROXY,
             _sUSDProxy: USD_PROXY,
             _oracle: PYTH,
-            _trustedForwarder: address(0x1)
+            _trustedForwarder: address(0x1),
+            _usdc: USDC
         });
 
         return (
@@ -170,7 +202,8 @@ contract BootstrapOptimismGoerli is Setup, OptimismGoerliParameters {
             SPOT_MARKET_PROXY,
             USD_PROXY,
             PYTH,
-            address(trustedForwarderContract)
+            address(trustedForwarderContract),
+            USDC
         );
     }
 }

--- a/test/utils/Bootstrap.sol
+++ b/test/utils/Bootstrap.sol
@@ -17,6 +17,7 @@ import {IERC20} from "src/interfaces/tokens/IERC20.sol";
 import {IPerpsMarketProxy} from "src/interfaces/synthetix/IPerpsMarketProxy.sol";
 import {ISpotMarketProxy} from "src/interfaces/synthetix/ISpotMarketProxy.sol";
 import {IPyth} from "src/interfaces/oracles/IPyth.sol";
+import {SynthetixMarketLookup} from "test/utils/SynthetixMarketLookup.sol";
 import {SynthMinter} from "test/utils/SynthMinter.sol";
 import {TrustedMulticallForwarder} from
     "lib/trusted-multicall-forwarder/src/TrustedMulticallForwarder.sol";
@@ -30,9 +31,14 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
     IPerpsMarketProxy public perpsMarketProxy;
     ISpotMarketProxy public spotMarketProxy;
     IERC20 public sUSD;
-    IERC20 public sBTC;
     IERC20 public USDC;
     IPyth public pyth;
+
+    // spot market id's
+    uint128 public sETHSpotMarketId;
+
+    // perps market id's
+    uint128 public sETHPerpsMarketId;
 
     SynthMinter public synthMinter;
     uint128 public accountId;
@@ -61,7 +67,6 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         sUSD = IERC20(_sUSDAddress);
         pyth = IPyth(_pythAddress);
         synthMinter = new SynthMinter(_sUSDAddress, _spotMarketProxyAddress);
-        sBTC = synthMinter.sBTC();
         USDC = IERC20(_usdcAddress);
 
         vm.startPrank(ACTOR);
@@ -74,6 +79,14 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         vm.stopPrank();
 
         synthMinter.mint_sUSD(ACTOR, AMOUNT);
+
+        SynthetixMarketLookup marketLookup = new SynthetixMarketLookup();
+        sETHSpotMarketId = marketLookup.findSpotMarketId(
+            "sETH Spot Market", address(spotMarketProxy)
+        );
+        sETHPerpsMarketId = marketLookup.findPerpsMarketId(
+            "SETH Perps Market", address(perpsMarketProxy)
+        );
 
         /// @custom:todo mint USDC?
     }
@@ -100,7 +113,6 @@ contract Bootstrap is Test, Constants, Conditions, SynthetixV3Errors {
         sUSD = IERC20(_sUSDAddress);
         pyth = IPyth(_pythAddress);
         synthMinter = new SynthMinter(_sUSDAddress, _spotMarketProxyAddress);
-        sBTC = synthMinter.sBTC();
         USDC = IERC20(_usdcAddress);
 
         vm.startPrank(ACTOR);

--- a/test/utils/Constants.sol
+++ b/test/utils/Constants.sol
@@ -44,13 +44,7 @@ contract Constants {
 
     uint128 internal constant SUSD_SPOT_MARKET_ID = 0;
 
-    uint128 internal constant SBTC_SPOT_MARKET_ID = 1;
-
-    uint128 internal constant SETH_SPOT_MARKET_ID = 2;
-
     uint128 internal constant INVALID_PERPS_MARKET_ID = type(uint128).max;
-
-    uint128 constant SETH_PERPS_MARKET_ID = 200;
 
     bytes32 constant PYTH_ETH_USD_ASSET_ID =
         0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6;

--- a/test/utils/SynthMinter.sol
+++ b/test/utils/SynthMinter.sol
@@ -2,21 +2,16 @@
 pragma solidity 0.8.20;
 
 import {Constants} from "test/utils/Constants.sol";
-import {IERC20} from "src/interfaces/tokens/IERC20.sol";
 import {ISpotMarketProxy} from "src/interfaces/synthetix/ISpotMarketProxy.sol";
 import {Test} from "lib/forge-std/src/Test.sol";
 
 contract SynthMinter is Test, Constants {
     address public immutable sUSD;
-    IERC20 public immutable sBTC;
     ISpotMarketProxy public immutable spotMarketProxy;
 
     constructor(address _sUSDAddress, address _spotMarketProxy) {
         sUSD = _sUSDAddress;
         spotMarketProxy = ISpotMarketProxy(_spotMarketProxy);
-        sBTC = IERC20(
-            ISpotMarketProxy(spotMarketProxy).getSynth(SBTC_SPOT_MARKET_ID)
-        );
     }
 
     function mint_sUSD(address target, uint256 amount) public {

--- a/test/utils/SynthetixMarketLookup.sol
+++ b/test/utils/SynthetixMarketLookup.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.20;
+
+contract SynthetixMarketLookup {
+    mapping(string => uint128) public spotMarketCache;
+    mapping(string => uint128) public perpsMarketCache;
+
+    error NotFound(string name);
+    error GetMarketsFailed(address proxy);
+
+    function findPerpsMarketId(string memory name, address proxy)
+        public
+        returns (uint128)
+    {
+        if (perpsMarketCache[name] != 0) {
+            return perpsMarketCache[name];
+        }
+
+        (bool s, bytes memory result) =
+            proxy.call(abi.encodeWithSignature("getMarkets()"));
+        if (s) {
+            uint128[] memory marketIds = abi.decode(result, (uint128[]));
+            uint128 id = _findMarketId(name, proxy, marketIds);
+            perpsMarketCache[name] = id;
+        } else {
+            revert GetMarketsFailed(proxy);
+        }
+
+        revert NotFound(name);
+    }
+
+    function findSpotMarketId(string memory name, address proxy)
+        public
+        returns (uint128)
+    {
+        if (spotMarketCache[name] != 0) {
+            return spotMarketCache[name];
+        }
+
+        (bool s, bytes memory result) =
+            proxy.call(abi.encodeWithSignature("getSynths()"));
+        if (s) {
+            uint128[] memory marketIds = abi.decode(result, (uint128[]));
+            uint128 id = _findMarketId(name, proxy, marketIds);
+            spotMarketCache[name] = id;
+        } else {
+            revert GetMarketsFailed(proxy);
+        }
+
+        revert NotFound(name);
+    }
+
+    function _findMarketId(
+        string memory name,
+        address proxy,
+        uint128[] memory marketIds
+    ) internal returns (uint128) {
+        for (uint128 i = 0; i <= marketIds.length; i++) {
+            (bool s, bytes memory result) =
+                proxy.call(abi.encodeWithSignature("name(uint128)", i));
+
+            if (s) {
+                string memory _name = abi.decode(result, (string));
+                if (_compare(_name, name)) {
+                    return i;
+                }
+            }
+        }
+
+        revert NotFound(name);
+    }
+
+    function _compare(string memory a, string memory b)
+        internal
+        pure
+        returns (bool)
+    {
+        return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
+    }
+}

--- a/test/utils/exposed/EngineExposed.sol
+++ b/test/utils/exposed/EngineExposed.sol
@@ -11,14 +11,16 @@ contract EngineExposed is Engine {
         address _spotMarketProxy,
         address _sUSDProxy,
         address _oracle,
-        address _trustedForwarder
+        address _trustedForwarder,
+        address _usdc
     )
         Engine(
             _perpsMarketProxy,
             _spotMarketProxy,
             _sUSDProxy,
             _oracle,
-            _trustedForwarder
+            _trustedForwarder,
+            _usdc
         )
     {}
 


### PR DESCRIPTION
Implement $USDC zap utility for the SMv3 `Engine` 

## Description
* Create `zap()`
* Test `zap()` ($USDC <-> $sUSD)
* Update interfaces
* Update `Engine.constructor()` with $USDC address
* Move test environment to newer block number on Base Goerli

## Related issue(s)
N/A

## Motivation and Context
$USDC zap function improves UX for FE Andromeda support