### PR TITLE
Update encoding type

### DIFF
--- a/src/libraries/ConditionalOrderHashLib.sol
+++ b/src/libraries/ConditionalOrderHashLib.sol
@@ -14,7 +14,7 @@ library ConditionalOrderHashLib {
 
     /// @notice pre-computed keccak256(ConditionalOrder struct)
     bytes32 public constant _CONDITIONAL_ORDER_TYPEHASH = keccak256(
-        "ConditionalOrder(OrderDetails orderDetails,address signer,uint256 nonce,bool requireVerified,address trustedExecutor,uint256 maxExecutorFee,bytes[] conditions)OrderDetails(uint128 marketId,uint128 accountId,int128 sizeDelta,uint128 settlementStrategyId,uint256 acceptablePrice,bool isReduceOnly,bytes32 trackingCode,address referrer)"
+        "ConditionalOrder(OrderDetails orderDetails,address signer,uint256 nonce,bool requireVerified,address trustedExecutor,uint256 maxExecutorFee,bytes32 conditions)OrderDetails(uint128 marketId,uint128 accountId,int128 sizeDelta,uint128 settlementStrategyId,uint256 acceptablePrice,bool isReduceOnly,bytes32 trackingCode,address referrer)"
     );
 
     /// @notice hash the OrderDetails struct


### PR DESCRIPTION
### Description

As the value was changed from array of bytes to hash of bytes32 maybe the encoding type also needs to be updated inline with that?

Related change: https://github.com/Kwenta/smart-margin-v3/pull/15/files#diff-45daff05a689f1e9fb67189b7f9aaed1cd4aa0d207c56401cda7c7d99a13a9c0R69